### PR TITLE
Fix scrollfactor in Parry UI anim

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -525,6 +525,7 @@ class PlayState extends MusicBeatState
 				  parrry.frames = Paths.getSparrowAtlas('parrry',"platform");
 				  parrry.animation.addByPrefix('parryanim', 'parryanim', 23, false); //yes, the 23 is intentional
 				  parrry.alpha=0;
+				  parrry.scrollFactor.set();
 
 				  parrry.antialiasing = ClientPrefs.globalAntialiasing;
 				  spacebar.antialiasing = ClientPrefs.globalAntialiasing;


### PR DESCRIPTION
Make the Parry UI anim not move when the camera moves

I haven't tested this it's probably in the wrong position